### PR TITLE
Add extention syntax (closes #13)

### DIFF
--- a/lib/src/parser.d.ts
+++ b/lib/src/parser.d.ts
@@ -6,6 +6,7 @@ export interface ListTree {
     value: string | null;
     parent: ListTree | null;
 }
+export declare type Plugin = (args: string, content: any) => string;
 export declare type Mapper<T> = (tagName: string, attributes?: any) => (children: string | T | null) => T;
 export interface ExportType<T> {
     mapper: Mapper<T>;
@@ -14,6 +15,9 @@ export interface ExportType<T> {
 export declare class Parser<T> {
     opts: {
         export: ExportType<T>;
+        plugins?: {
+            [pluginName: string]: Plugin;
+        };
     };
     liLevelBefore: number | null;
     liLevel: number | null;
@@ -22,6 +26,9 @@ export declare class Parser<T> {
     acceptables: P.Parser<T>;
     constructor(opts: {
         export: ExportType<T>;
+        plugins?: {
+            [pluginName: string]: Plugin;
+        };
     });
     create(): void;
     parse(s: string): T | undefined;

--- a/lib/src/parser.d.ts
+++ b/lib/src/parser.d.ts
@@ -6,7 +6,7 @@ export interface ListTree {
     value: string | null;
     parent: ListTree | null;
 }
-export declare type Plugin = (args: string, content: any) => string;
+export declare type Plugin<T> = (args: string, content: any, mapper: Mapper<T>, join: Function) => string;
 export declare type Mapper<T> = (tagName: string, attributes?: any) => (children: string | T | null) => T;
 export interface ExportType<T> {
     mapper: Mapper<T>;
@@ -17,7 +17,7 @@ export declare class Parser<T> {
     opts: {
         export: ExportType<T>;
         plugins?: {
-            [pluginName: string]: Plugin;
+            [pluginName: string]: Plugin<T>;
         };
     };
     liLevelBefore: number | null;
@@ -28,7 +28,7 @@ export declare class Parser<T> {
     constructor(opts: {
         export: ExportType<T>;
         plugins?: {
-            [pluginName: string]: Plugin;
+            [pluginName: string]: Plugin<T>;
         };
     });
     create(): void;

--- a/lib/src/parser.js
+++ b/lib/src/parser.js
@@ -92,7 +92,8 @@ var Parser = (function () {
             .map(mapper("code"))
             .skip(codeEnd);
         var pluginInline = P.seqMap(P.string("@["), P.regexp(/[a-zA-Z]+/), P.regexp(/:{0,1}([^\]]*)/, 1), P.string("]"), function (_1, pluginName, args, _2) {
-            return _this.opts.plugins && _this.opts.plugins[pluginName] ? _this.opts.plugins[pluginName](args, null) : join([_1, pluginName, args, _2]);
+            return _this.opts.plugins && _this.opts.plugins[pluginName] ?
+                _this.opts.plugins[pluginName](args, null, mapper, join) : join([_1, pluginName, args, _2]);
         });
         var inline = P.alt(pluginInline, anchor, img, em, strong, code, P.regexp(/[^\r\n=-\[\]\*\`\@]+/), P.regexp(/./));
         var tdStr = P.regexp(/[^\r\n\[\]\*|`]+(?= \|)/);
@@ -235,7 +236,8 @@ var Parser = (function () {
             }).map(mapper("p")).map(mapper("blockquote")).skip(whitespace.many());
         });
         var pluginBlock = P.seqMap(P.string("@["), P.regexp(/[a-zA-Z]+/), P.regexp(/(:[^\]]*)*/), P.string("]\n"), P.seq(P.string("  ").result(""), P.regexp(/[^\r\n]+/), linebreak.atMost(1).result("\n")).map(join).atLeast(1).map(join), function (_1, pluginName, args, _2, content) {
-            return _this.opts.plugins && _this.opts.plugins[pluginName] ? _this.opts.plugins[pluginName](args, content) : join([_1, pluginName, args, _2, content]);
+            return _this.opts.plugins && _this.opts.plugins[pluginName] ? _this.opts.plugins[pluginName](args, content, mapper, join)
+                : join([_1, pluginName, args, _2, content]);
         });
         var block = P.alt(P.regexp(/\s+/).result(""), pluginBlock, lists, h1Special, h2Special, h6, h5, h4, h3, h2, h1, table, codeBlock, blockquote, paragraph, linebreak.result(""));
         this.acceptables = P.alt(block).many().map(join);

--- a/lib/src/parser.js
+++ b/lib/src/parser.js
@@ -90,7 +90,10 @@ var Parser = (function () {
             .then(plainStr)
             .map(mapper("code"))
             .skip(codeEnd);
-        var inline = P.alt(anchor, img, em, strong, code, P.regexp(/[^\r\n=-\[\]\*\`]+/), P.regexp(/./));
+        var pluginInline = P.seqMap(P.string("@["), P.regexp(/[a-zA-Z]+/), P.regexp(/:{0,1}([^\]]*)/, 1), P.string("]"), function (_1, pluginName, args, _2) {
+            return _this.opts.plugins && _this.opts.plugins[pluginName] ? _this.opts.plugins[pluginName](args, null) : join([_1, pluginName, args, _2]);
+        });
+        var inline = P.alt(pluginInline, anchor, img, em, strong, code, P.regexp(/[^\r\n=-\[\]\*\`\@]+/), P.regexp(/./));
         var tdStr = P.regexp(/[^\r\n\[\]\*|`]+(?= \|)/);
         var tableInline = tdStr;
         var tableStart = P.string("| ");
@@ -228,7 +231,10 @@ var Parser = (function () {
                 return x.reduce(function (a, b) { return join([a, mapper("br")(null), b]); });
             }).map(mapper("p")).map(mapper("blockquote")).skip(whitespace.many());
         });
-        var block = P.alt(P.regexp(/\s+/).result(""), lists, h1Special, h2Special, h6, h5, h4, h3, h2, h1, table, codeBlock, blockquote, paragraph, linebreak.result(""));
+        var pluginBlock = P.seqMap(P.string("@["), P.regexp(/[a-zA-Z]+/), P.regexp(/(:[^\]]*)*/), P.string("]\n"), P.seq(P.string("  ").result(""), P.regexp(/[^\r\n]+/), linebreak.atMost(1).result("\n")).map(join).atLeast(1).map(join), function (_1, pluginName, args, _2, content) {
+            return _this.opts.plugins && _this.opts.plugins[pluginName] ? _this.opts.plugins[pluginName](args, content) : join([_1, pluginName, args, _2, content]);
+        });
+        var block = P.alt(P.regexp(/\s+/).result(""), pluginBlock, lists, h1Special, h2Special, h6, h5, h4, h3, h2, h1, table, codeBlock, blockquote, paragraph, linebreak.result(""));
         this.acceptables = P.alt(block).many().map(join);
     };
     Parser.prototype.parse = function (s) {

--- a/lib/test/test-parser.js
+++ b/lib/test/test-parser.js
@@ -161,6 +161,30 @@ describe("parser", function () {
         var expect = "<table><tr><th>a</th><th>b</th><th>c</th></tr><tr><td>d</td><td>e</td><td>f</td></tr></table>";
         assert.equal(parser_1.parse(input), expect);
     });
+    it("should parse extension syntax", function () {
+        var p = new parser_1.Parser({
+            export: parser_1.asHTML,
+            plugins: {
+                id: function (args, str) {
+                    return str;
+                }
+            }
+        });
+        var input = "\n@[id]\n  this should be showed as plain string\n  following string also should be treated as content\n";
+        assert.equal(p.parse(input), "this should be showed as plain string\nfollowing string also should be treated as content\n");
+    });
+    it("should parse inline extension syntax", function () {
+        var p = new parser_1.Parser({
+            export: parser_1.asHTML,
+            plugins: {
+                print: function (args, str) {
+                    return args;
+                }
+            }
+        });
+        var input = "\nx is @[print:40]\n";
+        assert.equal(p.parse(input), "<p>x is 40</p>");
+    });
     describe("courner cases", function () {
         it("should parse h1 after paragraph", function () {
             var input = "para\n\n# h1\n\npara\npara";

--- a/lib/test/test-parser.js
+++ b/lib/test/test-parser.js
@@ -304,4 +304,20 @@ describe("parser", function () {
             assert.deepEqual(parser.parse(input), expect);
         });
     });
+    describe('Extention', function () {
+        it('can be extended by user', function () {
+            var plugins = {
+                'extention': function (args, content, mapper, join) {
+                    return mapper('extention', null)(content.trim());
+                }
+            };
+            var parser = new parser_1.Parser({
+                export: parser_1.asHTML,
+                plugins: plugins
+            });
+            var input = "\n      @[extention]\n        user value\n ";
+            var expect = "<extention>user value</extention>";
+            assert.equal(parser.parse(input), expect);
+        });
+    });
 });

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -15,7 +15,7 @@ interface ListTree {
 }
 
 export
-type Plugin = (args: string, content: any) => string
+type Plugin<T> = (args: string, content: any, mapper: Mapper<T>, join: Function) => string
 
 export
 type Mapper<T> = (tagName: string, attributes?: any) => (children: string | T | null) => T
@@ -46,7 +46,7 @@ class Parser<T> {
   acceptables: P.Parser<T>
   constructor(public opts: {
     export: ExportType<T>
-    plugins?: {[pluginName: string]: Plugin}
+    plugins?: {[pluginName: string]: Plugin<T>}
   }) {
     this.create()
   }
@@ -172,7 +172,8 @@ class Parser<T> {
       P.regexp(/:{0,1}([^\]]*)/, 1),
       P.string("]"),
       (_1, pluginName, args, _2) => {
-        return this.opts.plugins && this.opts.plugins[pluginName] ? this.opts.plugins[pluginName](args, null) : join([_1, pluginName, args, _2])
+        return this.opts.plugins && this.opts.plugins[pluginName] ?
+          this.opts.plugins[pluginName](args, null, mapper, join) : join([_1, pluginName, args, _2])
       }
     )
 
@@ -378,7 +379,8 @@ class Parser<T> {
         linebreak.atMost(1).result("\n"),
       ).map(join).atLeast(1).map(join),
       (_1, pluginName, args, _2, content) => {
-        return this.opts.plugins && this.opts.plugins[pluginName] ? this.opts.plugins[pluginName](args, content) : join([_1, pluginName, args, _2, content])
+        return this.opts.plugins && this.opts.plugins[pluginName] ? this.opts.plugins[pluginName](args, content, mapper, join)
+          : join([_1, pluginName, args, _2, content])
       }
     )
     const block = P.alt(

--- a/test/test-parser.ts
+++ b/test/test-parser.ts
@@ -437,4 +437,25 @@ code block
 
     })
   })
+  describe('Extention', () => {
+    it('can be extended by user', () => {
+      const plugins = {
+        'extention': (args: string, content: string, mapper: Function, join: Function) => {
+          return mapper('extention', null)(content.trim())
+        }
+      }
+      const parser = new Parser({
+        export: asHTML,
+        plugins
+      })
+      const input = `
+      @[extention]
+        user value
+ `
+      const expect = `<extention>user value</extention>`
+
+      assert.equal(parser.parse(input), expect)
+
+    })
+  })
 })

--- a/test/test-parser.ts
+++ b/test/test-parser.ts
@@ -1,6 +1,6 @@
 import * as assert from 'power-assert'
 
-import {parse, Parser, asAST} from "../src/parser"
+import {parse, Parser, asAST, asHTML} from "../src/parser"
 
 describe("parser", () => {
   it('should parse h1', () => {
@@ -230,6 +230,36 @@ para`
 | d | e | f |`
     const expect = `<table><tr><th>a</th><th>b</th><th>c</th></tr><tr><td>d</td><td>e</td><td>f</td></tr></table>`
     assert.equal(parse(input), expect)
+  })
+  it("should parse extension syntax", () => {
+    const p = new Parser({
+      export: asHTML,
+      plugins: {
+        id: (args, str) => {
+          return str
+        }
+      }
+    })
+    const input = `
+@[id]
+  this should be showed as plain string
+  following string also should be treated as content
+`
+    assert.equal(p.parse(input), "this should be showed as plain string\nfollowing string also should be treated as content\n")
+  })
+  it("should parse inline extension syntax", () => {
+    const p = new Parser({
+      export: asHTML,
+      plugins: {
+        print: (args, str) => {
+          return args
+        }
+      }
+    })
+    const input = `
+x is @[print:40]
+`
+    assert.equal(p.parse(input), "<p>x is 40</p>")
   })
   describe("courner cases", () => {
     it("should parse h1 after paragraph", () => {


### PR DESCRIPTION
This changes are highly experimental and backward-incompatible.

## Motivation
Add flexibility to markdown.

## Syntax
```
@[pluginName:attributes]
  contents
```
or:
```
Use inside inline like @[pluginName:attributes]
```
All plugin name should be [a-zA-Z]+
`attributes` is just a plain string, we do not parse it, so like this one is syntactically allowed:
```
@[pluginName:  this is okay  ]
```